### PR TITLE
Add gated commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: Continuous integration
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Run unit tests
+        run: bash ./gradlew test --stacktrace
+
+  apk:
+    name: Build APK
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build debug APK
+        run: bash ./gradlew assembleDebug --stacktrace


### PR DESCRIPTION
Add continuous integration (CI) and gated commits with GitHub Actions. I used the Github-Android-Action action from the Marketplace [[1]] as a starting point and modified it.

[1]: https://github.com/marketplace/actions/android-github-action